### PR TITLE
Added feature: If local ip and/or dns server variables in wgjailr are not set, read them from the Wireguard .conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The `e` command allows executing a command in the network namespace as the curre
 The following variables are configurable, just change them at the top of the script:
 * `NETWORK_NAMESPACE_NAME`: The name of the network namespace. Default is `vpn`.
 * `VPN_CONFIG_PATH`: The path to your VPN configuration file. Default is `/opt/wireguard.conf`.
-* `VPN_DNS_SERVER`: The DNS server to be used in the network namespace. Default is `10.2.0.1`.
+* `VPN_DNS_SERVER`: The DNS server to be used in the network namespace. If not set, will be read from the wireguard .conf file.
 * `VPN_INTERFACE_NAME`: The name of the VPN interface in the network namespace. Default is `tun0`.
-* `VPN_LOCAL_IP`: The local IP address assigned to the VPN interface in the network namespace. Default is `10.2.0.2/32`.
+* `VPN_LOCAL_IP`: The local IP address assigned to the VPN interface in the network namespace. If not set, will be read from the wireguard .conf file.
 
 ## Systemd Unit Files
 In addition to the shell script, there are several Systemd unit files that are used to run the script on system start-up, forward a port from the root network namespace to the namespaced network, and run a service in the network namespace, effectively jailing the service to the network namespace.

--- a/bin/wgjailr
+++ b/bin/wgjailr
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # CONFIGURABLES #########################################################################################################
 # the name of the network namespace
@@ -14,7 +15,7 @@ VPN_LOCAL_IP=10.2.0.2/32
 ########################################################################################################################
 
 # enable for debugging output
-# set -ex
+# set -x
 
 # check if we are root, and if not, re-execute the script as root
 [[ $UID != 0 ]] && exec sudo -E "$(readlink -f "$0")" "$@"

--- a/bin/wgjailr
+++ b/bin/wgjailr
@@ -7,15 +7,17 @@ NETWORK_NAMESPACE_NAME=vpn
 # the path to the wireguard config file
 VPN_CONFIG_PATH=/opt/wireguard.conf
 # the DNS server from your wireguard config file
-VPN_DNS_SERVER=10.2.0.1
+# if empty, will be read from the wireguard .conf file
+VPN_DNS_SERVER=""
 # the name of the wireguard interface
 VPN_INTERFACE_NAME=tun0
 # the local IP address from your wireguard config file
-VPN_LOCAL_IP=10.2.0.2/32
+# if empty, will be read from the wireguard .conf file
+VPN_LOCAL_IP=""
 ########################################################################################################################
 
 # enable for debugging output
-# set -x
+#set -x
 
 # check if we are root, and if not, re-execute the script as root
 [[ $UID != 0 ]] && exec sudo -E "$(readlink -f "$0")" "$@"
@@ -38,14 +40,44 @@ up() {
   ip link set "$VPN_INTERFACE_NAME" netns "$NETWORK_NAMESPACE_NAME"
 
   ip netns exec "$NETWORK_NAMESPACE_NAME" wg setconf "$VPN_INTERFACE_NAME" <(wg-quick strip "$VPN_CONFIG_PATH")
-  ip -n "$NETWORK_NAMESPACE_NAME" a add "$VPN_LOCAL_IP" dev "$VPN_INTERFACE_NAME"
+  
+  # If the VPN_LOCAL_IP variable is set, we use it. If not, we read the ips from the wireguard config
+  if [ -z "$VPN_LOCAL_IP" ]
+  then
+    # First, delete the whitespace (spaces and tabs), since it is irrelevant and deleting it makes parsing easier
+    # Then we get the values of every line that contains an Address entry
+    # Then, since every Address line can have multiple ip addresses separated by comma, we make a newline separated list of ips by replacing the commas with newlines
+    LOCAL_IP_LIST="$(cat "$VPN_CONFIG_PATH" | tr -d ' ' | tr -d '\t' | awk -F '=' '$1 == "Address" {print $2}' | tr ',' '\n')"
+    # Now we set the ips from the generated list. Also works for IPv6
+    for ip in $LOCAL_IP_LIST
+    do
+      ip -n "$NETWORK_NAMESPACE_NAME" address add "$ip" dev "$VPN_INTERFACE_NAME"
+    done
+  else
+    ip -n "$NETWORK_NAMESPACE_NAME" address add "$VPN_LOCAL_IP" dev "$VPN_INTERFACE_NAME"
+  fi
   ip -n "$NETWORK_NAMESPACE_NAME" link set "$VPN_INTERFACE_NAME" up
 
   # set the default route in the new namespace
   ip -n "$NETWORK_NAMESPACE_NAME" route add default dev "$VPN_INTERFACE_NAME"
 
   # set network namespace resolv.conf
-  mkdir -p /etc/netns/"$NETWORK_NAMESPACE_NAME"/ && echo "nameserver $VPN_DNS_SERVER" > /etc/netns/"$NETWORK_NAMESPACE_NAME"/resolv.conf
+  mkdir -p /etc/netns/"$NETWORK_NAMESPACE_NAME"/
+  
+  # If the VPN_DNS_SERVER variable is set, we use it. If not, we read the ips from the wireguard config
+  if [ -z "$VPN_DNS_SERVER" ]
+  then
+    # First, delete the whitespace (spaces and tabs), since it is irrelevant and deleting it makes parsing easier
+    # Then we get the values of every line that contains a DNS entry
+    # Then, since every DNS line can have multiple ip addresses separated by comma, we make a newline separated list of ips by replacing the commas with newlines
+    DNS_SERVER_LIST="$(cat "$VPN_CONFIG_PATH" | tr -d ' ' | tr -d '\t' | awk -F '=' '$1 == "DNS" {print $2}' | tr ',' '\n')"
+    for dns_server in $DNS_SERVER_LIST
+    do
+      echo "nameserver $dns_server" >> /etc/netns/"$NETWORK_NAMESPACE_NAME"/resolv.conf
+    done
+  else
+    echo "nameserver $VPN_DNS_SERVER" > /etc/netns/"$NETWORK_NAMESPACE_NAME"/resolv.conf
+  fi
 }
 
 # bring down the network namespace and wireguard interface


### PR DESCRIPTION
This adds the functionality requested in: https://github.com/moismailzai/wgjailr/issues/2

It works as follows:
Since both the "Address" and the "DNS" fields are not in the base specification of a Wireguard configuration file, but are an extension introduced for wg-quick (compare the config file definitions in "man wg" and "man wg-quick"), I decided to retain the possibility to set both the address assigned to the interface as well as the DNS server via the config variables in wgjailr.
However, now, if these variables are left empty, wgjailr will read these values from the .conf file.

Since the manpage says ("man wg-quick") that both, Address and DNS, can be specified multiple times in the config file and are each comma separated lists of IP addresses, the parsing has multiple steps. I commented the code to make it easy to understand. I have used AWK for a portion of the parsing, but since AWK is defined in the POSIX standard, it can safely be assumed to be installed on an overwhelming majority of platforms where this script will be run (awk is even in busybox).

Also, in the first commit of this PR, I enabled "set -e" by default, since the code of wgjailr was already prepared for that and it seemed it was used for debugging. But since "set -e" is pretty much always a good idea in a shell script, in my opinion enabling it per default has only benefits and no downsides. However, for the feature to work, this change could be omitted if desired.